### PR TITLE
Version 2.0.5

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class FakeItConan(ConanFile):
     name = 'FakeIt'
-    version = '2.0.4'
+    version = '2.0.5'
     description = 'C++ mocking made easy. A simple yet very expressive, headers only library for c++ mocking.'
     settings = None
     options = {'integration': ['boost', 'gtest', 'mstest', 'standalone', 'tpunit', 'catch', 'qtest', 'mettle']}


### PR DESCRIPTION
Consider following the `stable/<version>` naming convention for branches (used by [bincrafters](https://github.com/bincrafters/)).

Note that version 2.0.5 is currently [pre-release](https://github.com/eranpeer/FakeIt/releases/tag/2.0.5) (as of writing this), but should be changed to release any day now.